### PR TITLE
Feature. Ensure minimum height on bar charts

### DIFF
--- a/lib/squid/point.rb
+++ b/lib/squid/point.rb
@@ -15,18 +15,39 @@ module Squid
           y = y_for value, index: i, stack: stack, &offset if value
           y = y - offset.call([min, 0].min) if value
           label = format_for value, formats[series_i] if labels[series_i]
-          new y: y, height: h, index: i, label: label, negative: value.to_f < 0
+          new y: y, height: h, index: i, label: label, stack: stack, negative: value.to_f < 0
         end
       end
     end
 
-    attr_reader :y, :height, :index, :label, :negative
+    attr_reader :index, :label, :negative, :stack
 
-    def initialize(y:, height:, index:, label:, negative:)
-      @y, @height, @index, @label, @negative = y, height, index, label, negative
+    def initialize(y:, height:, index:, label:, negative:, stack:)
+      @y, @height, @index, @label, @negative, @stack = y, height, index, label, negative, stack
+    end
+
+    def height
+      return unless @height
+      @height + height_offset
+    end
+
+    def y
+      return unless @y
+      @y + height_offset
     end
 
   private
+
+    # Ensures values of zero are visible by setting a minimum height
+    #
+    # @note
+    #   We also adjust the height of zero-values on charts with negative values.
+    #   If this is deemed undesirable in the future, change the code below to:
+    #     @y == 0 && @height == 0 && !stack ? 2 : 0
+    #
+    def height_offset
+      @height == 0 && !stack ? 2 : 0
+    end
 
     def self.y_for(value, index:, stack:, &block)
       if stack

--- a/spec/point_spec.rb
+++ b/spec/point_spec.rb
@@ -59,5 +59,19 @@ describe Squid::Point do
         expect(points.last.map &:y).to eq [nil, 89.95, 0.0]
       end
     end
+
+    context 'given a series containing a value of zero' do
+      let(:series) { [[0, 109.9, 30.0], [nil, 20.0, -50.0]] }
+
+      it 'offsets y to compensate for minimum height' do
+        # First y-value is lifted from 25 to 27 to match minimum height
+        expect(points.first.map &:y).to eq [27.0, 79.95, 40.0]
+      end
+
+      it 'ensures a minimum height' do
+        # First height is lifted from 0 to 2 to ensure it's visible on graph
+        expect(points.first.map &:height).to eq [2.0, 54.95, 15.0]
+      end
+    end
   end
 end


### PR DESCRIPTION
Evovia vil gerne have at man altid kan se den lavest mulige score på grafer. I stedet for at manipulere med chart data og lave en masse grimme hacks, fandt jeg det sted i Squid hvor højden beregnes og lavede det til en feature dér. Vi maintainer i forvejen et fork af Squid for at imødekomme nogle af deres krav, så det føltes som den bedste løsning. 

<img width="1378" alt="Screenshot 2023-01-18 at 10 27 49" src="https://user-images.githubusercontent.com/18333420/213137294-fbb86c88-2bcd-429e-ae5e-b6fffa3025b5.png">


**En lille note:** Søjler får også en minimumhøjde på grafer med negative værdier. Det tænkte jeg gav mest mening, hvis problemet vi forsøger at løse er at man ikke kan se værdier på 0 visuelt på grafen. Vi har ikke nogle steder hvor vi tegner grafer med negative værdier (i 360 kan scores gå ned til -4, men der tegner vi grafen på en helt anden måde), men skulle vi få det en dag, er vi klar til det. 

Hvis de ikke vil have at man skal kunne se 0-værdier på grafer med negative scores, har jeg tilføjet en kommentar i koden om hvordan vi får det til at ske. Så vi ikke skal tænke problemet igennem igen til den tid 🙂


 
<img width="825" alt="Screenshot 2023-01-18 at 10 47 00" src="https://user-images.githubusercontent.com/18333420/213138382-dea600b1-5234-47b9-b251-18629a5ee4c7.png">

Da vi ikke kører Squid på semaphore er der her lige et bevis for grøn testsuite ✅
<img width="517" alt="Screenshot 2023-01-18 at 10 48 28" src="https://user-images.githubusercontent.com/18333420/213138863-f745e1c4-0ff0-4c65-91b0-14e0e16e0c6a.png">
