### PR TITLE
New formats for axis labels

### DIFF
--- a/lib/squid/axis.rb
+++ b/lib/squid/axis.rb
@@ -25,7 +25,7 @@ module Squid
       else
         max.step(by: (min - max)/@steps.to_f, to: min)
       end
-      @labels ||= @axis_config.add_labels_to values.map{|value| format_for value, @format}
+      @labels ||= @axis_config.add_labels_to formatted_axis_labels(values)
     end
 
     def width
@@ -60,6 +60,15 @@ module Squid
 
     def approximate(number)
       number_to_rounded(number, significant: true, precision: 2).to_f
+    end
+
+    def formatted_axis_labels(values)
+      # When no axis labels have significant zeros we draw them as integers
+      if @format == :float && values.all? { |value| (value % 1).zero? }
+        values.map { |value| format_for value, :integer }
+      else
+        values.map { |value| format_for value, @format }
+      end
     end
   end
 end

--- a/lib/squid/format.rb
+++ b/lib/squid/format.rb
@@ -24,7 +24,7 @@ module Squid
     end
 
     def number_to_float(value)
-      float = number_to_rounded value, significant: true, precision: 2
+      float = number_to_rounded value, significant: false, precision: 1
       number_to_delimited float
     end
 

--- a/spec/axis_spec.rb
+++ b/spec/axis_spec.rb
@@ -73,8 +73,8 @@ describe Squid::Axis do
 
     describe 'given :float format' do
       let(:format) { :float }
-      it 'returns the labels as floats with all significant digits' do
-        expect(labels).to eq %w(9.9 -5.1 -20 -35 -50)
+      it 'returns the labels as floats with one decimal number and ignoring significant digits' do
+        expect(labels).to eq %w(9.9 -5.1 -20.0 -35.0 -50.0)
       end
     end
   end

--- a/spec/axis_spec.rb
+++ b/spec/axis_spec.rb
@@ -76,6 +76,14 @@ describe Squid::Axis do
       it 'returns the labels as floats with one decimal number and ignoring significant digits' do
         expect(labels).to eq %w(9.9 -5.1 -20.0 -35.0 -50.0)
       end
+
+      describe 'when axis labels only contains floats with insignificant zeros' do
+        let(:series) { [[-1.0, 0.0, 1.0], [-2.0, 0.0, 2.0]] }
+
+        it 'renders them as integers' do
+          expect(labels).to eq %w(2 1 0 -1 -2)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Et lille PR der tilpasser måden vi afrunder tal på i grafer, jf. [Jonas kommentarer på PT.](https://www.pivotaltracker.com/story/show/184211995)

* Vi fjerner nu altid ubetydende nuller på y-aksen
* Vi afrunder nu altid tallet over søjlerne til 1 decimaltal, og ignorerer alt hvad der hedder betydende cifre 

## Før
<img width="1207" alt="Screenshot 2023-03-14 at 08 20 42" src="https://user-images.githubusercontent.com/18333420/224925193-387d52b4-5605-48b3-b130-335fab802513.png">

## Efter
<img width="1214" alt="Screenshot 2023-03-14 at 08 20 30" src="https://user-images.githubusercontent.com/18333420/224925214-ea21d288-baf0-4dd3-87d1-464a1fef747f.png">

## Test output (fordi squid ikke kører på CI)
<img width="498" alt="Screenshot 2023-03-14 at 08 18 05" src="https://user-images.githubusercontent.com/18333420/224925544-1e3c05c2-9138-4b64-b3e4-5213f11d93f6.png">
